### PR TITLE
#3 Don’t use the companion object’s apply method to trigger derivation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Yet another enumeration toolbox for Scala, powered by [shapeless](https://github
 ## Installation
 
 Several artifacts are available:
+ - [![Maven Central](https://img.shields.io/maven-central/v/org.julienrf/enum_2.11.svg)](https://maven-badges.herokuapp.com/maven-central/org.julienrf/enum_2.11) `enum`: finds the values and labels of an enumeration and a mapping to go from a value to its label and _vice versa_.
  - [![Maven Central](https://img.shields.io/maven-central/v/org.julienrf/enum-values_2.11.svg)](https://maven-badges.herokuapp.com/maven-central/org.julienrf/enum-values_2.11) `enum-values`: finds the set of values of an enumeration ;
  - [![Maven Central](https://img.shields.io/maven-central/v/org.julienrf/enum-labels_2.11.svg)](https://maven-badges.herokuapp.com/maven-central/org.julienrf/enum-labels_2.11) `enum-labels`: finds the set of value names of an enumeration ;
- - [![Maven Central](https://img.shields.io/maven-central/v/org.julienrf/enum_2.11.svg)](https://maven-badges.herokuapp.com/maven-central/org.julienrf/enum_2.11) `enum`: finds the values and labels of an enumeration and a mapping to go from a value to its label and _vice versa_.
 
 The artifacts are built for Scala 2.10 and 2.11 and Scala.js 0.6.
 
@@ -25,36 +25,14 @@ object Foo {
 }
 ~~~
 
-### `enum-values`
-
-Use `Values[A]` to automatically gather all the `A` enumeration values as a `Set[A]`:
-
-~~~ scala
-import julienrf.enum.Values
-
-val fooValues: Values[Foo] = Values[Foo]
-
-fooValues.values == Set(Foo.Bar, Foo.Baz)
-~~~
-
-### `enum-labels`
-
-Use `Labels[A]` to automatically gather all the `A` enumeration labels as a `Set[String]`:
-
-~~~ scala
-import julienrf.enum.Labels
-
-val fooLabels: Labels[Foo] = Labels[Foo]
-
-fooLabels.labels == Set("Bar", "Baz")
-~~~
-
 ### `enum`
+
+Use `Enum.derived[A]` to derive an `Enum[A]` value that provides several useful methods:
 
 ~~~ scala
 import julienrf.enum.{Enum, DecodingFailure}
 
-val enum: Enum[Foo] = Enum[Foo]
+val enum: Enum[Foo] = Enum.derived[Foo]
 
 enum.values == Set(Foo.Bar, Foo.Baz)
 enum.labels == Set("Bar", "Baz")
@@ -64,8 +42,36 @@ enum.decode("invalid") == Left(DecodingFailure[Foo](Set("Bar", "Baz")))
 enum.decodeOpt("Baz") == Some(Foo.Baz)
 ~~~
 
+### `enum-values`
+
+Use `Values.derived[A]` to automatically gather all the `A` enumeration values as a `Set[A]`:
+
+~~~ scala
+import julienrf.enum.Values
+
+val fooValues: Values[Foo] = Values.derived[Foo]
+
+fooValues.values == Set(Foo.Bar, Foo.Baz)
+~~~
+
+### `enum-labels`
+
+Use `Labels.derived[A]` to automatically gather all the `A` enumeration labels as a `Set[String]`:
+
+~~~ scala
+import julienrf.enum.Labels
+
+val fooLabels: Labels[Foo] = Labels.derived[Foo]
+
+fooLabels.labels == Set("Bar", "Baz")
+~~~
+
 ## Changelog
 
+- 3.0
+    - Breaking change: the companion object’s `apply` method that was used to derive enumerations
+      has been renamed to `derived`. The `apply` method still exists but it now returns the
+      implicitly available instance.
 - 2.2
     - Update shapeless to 2.3.0 and Scala.js to 0.6.7
 - 2.1

--- a/enum/src/main/scala/julienrf/enum/Encoder.scala
+++ b/enum/src/main/scala/julienrf/enum/Encoder.scala
@@ -13,12 +13,14 @@ trait Encoder[A] {
 
 object Encoder {
 
+  @inline def apply[A](implicit encoder: Encoder[A]): Encoder[A] = encoder
+
   trait Derived[A] extends Encoder[A]
 
   /**
     * @return A generated encoder for `A` values
     */
-  @inline def apply[A](implicit derived: Derived[A]): Encoder[A] = derived
+  @inline implicit def derived[A](implicit derived: Derived[A]): Encoder[A] = derived
 
   object Derived {
     /**

--- a/enum/src/main/scala/julienrf/enum/Enum.scala
+++ b/enum/src/main/scala/julienrf/enum/Enum.scala
@@ -7,7 +7,7 @@ package julienrf.enum
   *     case object Bar extends Foo
   *     case object Baz extends Foo
   *
-  *     val enum: Enum[Foo] = Enum[Foo]
+  *     val enum: Enum[Foo] = Enum.derived[Foo]
   *   }
   *
   *   assert(Foo.enum.values == Set(Foo.Bar, Foo.Baz))
@@ -41,13 +41,13 @@ trait Enum[A] {
 
 case class DecodingFailure[A](validValues: Set[String])
 
-object Enum extends Enum1
+object Enum {
 
-trait Enum1 {
+  @inline def apply[A](implicit enum: Enum[A]): Enum[A] = enum
 
   trait Derived[A] extends Enum[A]
 
-  @inline def apply[A](implicit derived: Derived[A]): Enum[A] = derived
+  @inline implicit def derived[A](implicit derived: Derived[A]): Enum[A] = derived
 
   object Derived {
     implicit def fromValuesAndEncoder[A](implicit _values: Values.Derived[A], encoder: Encoder.Derived[A]): Derived[A] =

--- a/enum/src/test/scala/julienrf/enum/EnumSuite.scala
+++ b/enum/src/test/scala/julienrf/enum/EnumSuite.scala
@@ -3,16 +3,21 @@ package julienrf.enum
 import org.scalatest.FunSuite
 
 class EnumSuite extends FunSuite {
-  import EnumSuite.Foo
+  import EnumSuite.{Foo, TwoLevels}
 
   test("Enum[Foo]") {
-    assert(Foo.enum.values == Set(Foo.Bar, Foo.Baz))
-    assert(Foo.enum.labels == Set("Bar", "Baz"))
-    assert(Foo.enum.encode(Foo.Bar) == "Bar")
-    assert(Foo.enum.decode("Baz") == Right(Foo.Baz))
-    assert(Foo.enum.decode("invalid") == Left(DecodingFailure[Foo](Set("Bar", "Baz"))))
-    assert(Foo.enum.decodeOpt("Bar") == Some(Foo.Bar))
-    assert(Foo.enum.decodeOpt("invalid") == None)
+    val enum = Enum[Foo]
+    assert(enum.values == Set(Foo.Bar, Foo.Baz))
+    assert(enum.labels == Set("Bar", "Baz"))
+    assert(enum.encode(Foo.Bar) == "Bar")
+    assert(enum.decode("Baz") == Right(Foo.Baz))
+    assert(enum.decode("invalid") == Left(DecodingFailure[Foo](Set("Bar", "Baz"))))
+    assert(enum.decodeOpt("Bar") == Some(Foo.Bar))
+    assert(enum.decodeOpt("invalid") == None)
+  }
+
+  test("Enum[TwoLevels]") {
+    assert(Enum[TwoLevels].labels == Set("FirstValue", "SecondValue", "ThirdValue"))
   }
 
 }
@@ -23,6 +28,13 @@ object EnumSuite {
     case object Bar extends Foo
     case object Baz extends Foo
 
-    val enum: Enum[Foo] = Enum[Foo]
+    implicit val enum: Enum[Foo] = Enum.derived
   }
+
+  sealed trait TwoLevels
+  case object FirstValue extends TwoLevels
+  sealed trait SecondLevel extends TwoLevels
+  case object SecondValue extends SecondLevel
+  case object ThirdValue extends SecondLevel
+  implicit val twoLevelsEnum: Enum[TwoLevels] = Enum.derived
 }

--- a/labels/src/main/scala/julienrf/enum/Labels.scala
+++ b/labels/src/main/scala/julienrf/enum/Labels.scala
@@ -3,16 +3,18 @@ package julienrf.enum
 import shapeless.labelled.FieldType
 import shapeless.{:+:, Witness, CNil, LabelledGeneric, Coproduct}
 
-/** Gives the names of all the subtypes of `A` */
+/** Gives the names of all the subtypes of `A`. Note that it is not limited to case objects. */
 trait Labels[A] {
   val labels: Set[String]
 }
 
 object Labels {
 
+  @inline def apply[A](implicit labels: Labels[A]): Labels[A] = labels
+
   trait Derived[A] extends Labels[A]
 
-  @inline def apply[A](implicit derived: Derived[A]): Labels[A] = derived
+  @inline implicit def derived[A](implicit derived: Derived[A]): Labels[A] = derived
 
   object Derived extends Derived1 {
 

--- a/labels/src/test/scala/julienrf/enum/LabelsSuite.scala
+++ b/labels/src/test/scala/julienrf/enum/LabelsSuite.scala
@@ -6,7 +6,7 @@ class LabelsSuite extends FunSuite {
   import LabelsSuite.Foo
 
   test("Labels[Foo]") {
-    assert(Foo.enum.labels == Set("Bar", "Baz"))
+    assert(Labels[Foo].labels == Set("Bar", "Baz"))
   }
 
 }
@@ -17,6 +17,6 @@ object LabelsSuite {
     case object Bar extends Foo
     case object Baz extends Foo
 
-    val enum: Labels[Foo] = Labels[Foo]
+    implicit val enum: Labels[Foo] = Labels.derived
   }
 }

--- a/values/src/main/scala/julienrf/enum/Values.scala
+++ b/values/src/main/scala/julienrf/enum/Values.scala
@@ -25,6 +25,8 @@ trait Values[A] {
   */
 object Values {
 
+  @inline def apply[A](implicit values: Values[A]): Values[A] = values
+
   trait Derived[A] extends Values[A]
 
   /**
@@ -33,13 +35,13 @@ object Values {
     *   object Foo {
     *     case object Bar extends Foo
     *     case object Baz extends Foo
-    *     val values = Values[Foo]
     *   }
+    *   Values.derived[Foo].values == Set(Foo.Bar, Foo.Baz)
     * }}}
     *
     * @return All the possible values of `A`
     */
-  @inline def apply[A](implicit derived: Derived[A]): Values[A] = derived
+  @inline implicit def derived[A](implicit derived: Derived[A]): Values[A] = derived
 
   object Derived {
     /**

--- a/values/src/test/scala/julienrf/enum/ValuesSuite.scala
+++ b/values/src/test/scala/julienrf/enum/ValuesSuite.scala
@@ -6,7 +6,7 @@ class ValuesSuite extends FunSuite {
   import ValuesSuite.Foo
 
   test("Values[Foo]") {
-    assert(Foo.enum.values == Set(Foo.Bar, Foo.Baz))
+    assert(Values[Foo].values == Set(Foo.Bar, Foo.Baz))
   }
 
 }
@@ -17,6 +17,6 @@ object ValuesSuite {
     case object Bar extends Foo
     case object Baz extends Foo
 
-    val enum: Values[Foo] = Values[Foo]
+    implicit val enum: Values[Foo] = Values.derived
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.4-SNAPSHOT"
+version in ThisBuild := "3.0-SNAPSHOT"


### PR DESCRIPTION
This is a fix for #3.

This PR breaks backward compatibility.
The `apply` method of companion objects has been renamed to `derived`.
Note that the `apply` method still exists but it now just retrieves the implicit instance.

Any previous code of the following form will now be a potential source of `NullPointerException`:

``` scala
implicit val enum: Enum[Foo] = Enum[Foo]
```

It **must** be replaced with:

``` scala
implicit val enum: Enum[Foo] = Enum.derived
```

I could introduce a smoother migration path by first deprecating the `apply` method, then removing it and finally re-introduce it (with its new behavior), but that would require 3 releases to be effective…
